### PR TITLE
Fixes for iOS platform

### DIFF
--- a/Assets/Plugins/DetectHeadset.cs
+++ b/Assets/Plugins/DetectHeadset.cs
@@ -9,7 +9,7 @@ public class DetectHeadset {
 
 	static public bool Detect() {
 
-		#if UNITY_IOS
+		#if UNITY_IOS  && !UNITY_EDITOR
 			return _Detect();
 
 		#elif UNITY_ANDROID && !UNITY_EDITOR

--- a/Assets/Plugins/iOS/DetectHeadset.mm
+++ b/Assets/Plugins/iOS/DetectHeadset.mm
@@ -11,6 +11,10 @@ extern "C" {
                 return true;
             if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothHFP])
                 return true;
+	    //It was displaying this route for bluetooth wireless headphones.
+            //Tested with Unity 2019.1
+            if ([[desc portType] isEqualToString:AVAudioSessionPortBluetoothA2DP])
+                return true;
         }
         
         return false;


### PR DESCRIPTION
1. Validation added in iOS .mm file for Bluetooth Headset.
2. Method redirection to native call diverted in iOS Editor